### PR TITLE
Fix: Change the gem name to cm-admin from cm_admin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,4 +52,4 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-gem 'cm_admin', path: '/home/aditya/commutatus/cm-admin'
+gem 'cm-admin', path: '/home/aditya/commutatus/cm-admin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /home/aditya/commutatus/cm-admin
   specs:
-    cm_admin (0.1.0)
+    cm-admin (0.3.0)
       axlsx_rails (~> 0.6.1)
       pagy (~> 3.13)
       slim (~> 4.1.0)
@@ -226,7 +226,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
-  cm_admin!
+  cm-admin!
   jbuilder (~> 2.7)
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)


### PR DESCRIPTION
The latest release of the gem has made a change in the name. The same needs to be added in project